### PR TITLE
Test conversion from stdin.

### DIFF
--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -129,7 +129,7 @@ class TestsBase(unittest.TestCase):
         return os.path.join(path, *names)
 
 
-    def nbconvert(self, parameters, ignore_return_code=False):
+    def nbconvert(self, parameters, ignore_return_code=False, stdin=None):
         """
         Run nbconvert as a shell command, listening for both Errors and
         non-zero return codes. Returns the tuple (stdout, stderr) of
@@ -145,8 +145,8 @@ class TestsBase(unittest.TestCase):
         if isinstance(parameters, string_types):
             parameters = shlex.split(parameters)
         cmd = [sys.executable, '-m', 'nbconvert'] + parameters
-        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        stdout, stderr = p.communicate()
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        stdout, stderr = p.communicate(input=stdin)
         if not (p.returncode == 0 or ignore_return_code):
             raise OSError(bytes_to_str(stderr))
         return stdout.decode('utf8', 'replace'), stderr.decode('utf8', 'replace')

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -5,16 +5,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import glob
-import sys
+import io
 
 from .base import TestsBase
 from ..postprocessors import PostProcessorBase
-from ..preprocessors.execute import CellExecutionError
 
 from traitlets.tests.utils import check_help_all_output
 from ipython_genutils.testing import decorators as dec
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_in, assert_not_in
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -305,8 +303,19 @@ class TestNbConvertApp(TestsBase):
             output2, _ = self.nbconvert('--to markdown --stdout notebook_jl.ipynb')
             assert '```julia' in output2  # shouldn't have language
             assert "```" in output2  # but should also plain ``` to close cell
+    
+    def test_convert_from_stdin(self):
+        """
+        Verify that conversion can be done via stdin, and that 
+        --stdin  implies --stdout. 
+        """
+        with self.create_temp_cwd(["notebook1.ipynb"]):
+            with io.open('notebook1.ipynb') as f:
+                notebook = f.read().encode()
+                output1, _ = self.nbconvert('--to markdown --stdin', stdin=notebook)
+            assert_not_in('```python', output1) # shouldn't have language
+            assert_in("```", output1) # but should have fenced blocks
 
-        pass
 
     @dec.onlyif_cmds_exist('pdflatex')
     @dec.onlyif_cmds_exist('pandoc')


### PR DESCRIPTION
Add ability to pass stdin to nbconvert test suite,
remove a few unused imports.
## 

Test where not super obvious to write, so I did it, you can expand if you like. 

You can run this particular lest with:

```
nosetests -w /tmp   nbconvert.tests.test_nbconvertapp:TestNbConvertApp.test_convert_from_stdin
```
